### PR TITLE
AmazonEC2ContainerServiceFullAccess phased out

### DIFF
--- a/cdk/src/EksCdk/EksCdkStack.cs
+++ b/cdk/src/EksCdk/EksCdkStack.cs
@@ -134,7 +134,7 @@ namespace EksCdk
             string[] taskDefinitionManagedRoleActions = new string[]{
               "AmazonRDSFullAccess",
               "AmazonSSMFullAccess",
-              "AmazonEC2ContainerServiceFullAccess",
+              "AmazonECS_FullAccess",
               "service-role/AmazonEC2ContainerServiceforEC2Role"
           };
           return taskDefinitionManagedRoleActions;


### PR DESCRIPTION
use `AmazonECS_FullAccess` in place of `AmazonEC2ContainerServiceFullAccess` as it was phased out. 

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/security-iam-awsmanpol-amazonecs-full-access-migration.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
